### PR TITLE
[EXAMPLE-3] Add Riverpod counter example

### DIFF
--- a/lib/common/ui/common.dart
+++ b/lib/common/ui/common.dart
@@ -16,7 +16,9 @@ class SwitchItem extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(text,style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.blueAccent)),
+        Text(text,
+            style: const TextStyle(
+                fontWeight: FontWeight.bold, color: Colors.blueAccent)),
         Switch(
           value: value,
           onChanged: onChanged,
@@ -37,6 +39,45 @@ class SlowFadeImage extends StatelessWidget {
       image: imageUrl,
       fadeOutDuration: const Duration(milliseconds: 3000),
       fadeInDuration: const Duration(milliseconds: 3000),
+    );
+  }
+}
+
+class ExampleCard extends StatelessWidget {
+  final String title;
+  final Widget child;
+  final bool useRepaintBoundary;
+  const ExampleCard({
+    super.key,
+    required this.title,
+    required this.child,
+    this.useRepaintBoundary = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 16, color: Colors.blueAccent),
+              textAlign: TextAlign.center,
+            ),
+            const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Divider(),
+            ),
+            useRepaintBoundary ? RepaintBoundary(child: child) : child,
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/examples/state/riverpod_counter_example/providers.dart
+++ b/lib/examples/state/riverpod_counter_example/providers.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// This is a [ChangeNotifierProvider] widget for Provider package.
+/// We can reference a concrete [MyIntNotifier] instance using the [counterProvider] in a child widget of [ProviderScope].
+/// Note that for testing purposes, we pass the type as [MyIntNotifier],
+/// so we can alternate with [_NegativeCounterNotifier].
+final counterProvider =
+    NotifierProvider< /*_CounterNotifier*/ MyIntNotifier, int>(
+        CounterNotifier.new);
+
+abstract class MyIntNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void operate();
+}
+
+/// Analog to Provider's ChangeNotifier.
+class CounterNotifier extends MyIntNotifier {
+  @override
+  void operate() => state++;
+}
+
+/// Alternate provider, to show how to override providers on [ProviderScope].
+class NegativeCounterNotifier extends MyIntNotifier {
+  @override
+  void operate() => state--;
+}

--- a/lib/examples/state/riverpod_counter_example/riverpod_counter_example.dart
+++ b/lib/examples/state/riverpod_counter_example/riverpod_counter_example.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_playground/common/ui/common.dart';
+import 'package:flutter_playground/examples/state/riverpod_counter_example/providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RiverpodCounterExampleScreen extends StatelessWidget {
+  const RiverpodCounterExampleScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Riverpod Counter Example'),
+      ),
+      body: Container(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            /// Typically [ProviderScope] is used as `runApp(ProviderScope())` so you can reference your providers
+            /// on the entire app.
+            /// Use it to set a scope where you want to use your Riverpod providers, see bellow how this
+            /// can be used as dependency injector.
+            ProviderScope(
+              child: ExampleCard(
+                title: "Positive counter",
+                child:
+
+                    /// Use [Consumer] to listen to [counterProvider] and avoid unnecessary repaints.
+                    /// "You should scope your provider consumption as locally as possible,
+                    /// only in the part of the widget tree where it’s actually needed.
+                    /// This helps to avoid unnecessary rebuilds and improves performance by limiting
+                    /// the area of the widget tree that reacts to provider changes."
+                    /// If [RiverpodCounterExampleScreen] was a [ConsumerWidget], the entire screen could
+                    /// repaint on state changes.
+                    /// Other option is extracting the below Column into a [ConsumerWidget].
+                    Consumer(
+                  builder: (context, ref, child) {
+                    final counter = ref.watch(counterProvider);
+
+                    return Column(
+                      children: [
+                        Text('Count: $counter'),
+                        ElevatedButton(
+                          onPressed: ref.read(counterProvider.notifier).operate,
+                          child: const Text('Increment'),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ),
+
+            /// Demo, how you can use inject another implementation for the same [_counterProvider] provider.
+            /// Pass [overrides] as dependency injector, so you could swap
+            /// between provider implementations.
+            ProviderScope(
+              overrides: [
+                counterProvider.overrideWith(() => NegativeCounterNotifier()),
+              ],
+              child: ExampleCard(
+                title: "Overriden provider, negative counter",
+
+                /// Consuming the provider at this point
+                child: Consumer(
+                  builder: (context, ref, child) {
+                    final counter = ref.watch(counterProvider);
+
+                    return Column(
+                      children: [
+                        Text('Count: $counter'),
+                        ElevatedButton(
+                          onPressed: ref.read(counterProvider.notifier).operate,
+                          child: const Text('Decrement'),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_playground/examples/state/provider_counter_example.dart';
+import 'package:flutter_playground/examples/state/riverpod_counter_example/riverpod_counter_example.dart';
 
 void main() {
   runApp(const MyApp());
@@ -18,10 +18,11 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey, brightness: Brightness.dark),
+        colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.blueGrey, brightness: Brightness.dark),
         useMaterial3: true,
       ),
-      home: const ProviderCounterExampleScreen(),
+      home: const RiverpodCounterExampleScreen(),
       // const WidgetRepaintBoundaryExampleScreen(),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,6 +70,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "0f1974eff5bbe774bf1d870e406fc6f29e3d6f1c46bd9c58e7172ff68a785d7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -155,6 +163,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: f21b32ffd26a36555e501b04f4a5dca43ed59e16343f1a30c13632b2351dfa4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -176,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.6
   provider: ^6.1.2
+  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* Add a simple `Riverpod` counter.
* Add examples of how to inject different `Notifier` instances overriding the providers and scope them with `ProviderScope`.


https://github.com/user-attachments/assets/3684b09f-56e9-4ad3-b847-8a592a434a49

